### PR TITLE
Prevent a panic in the error encoder

### DIFF
--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -172,7 +172,8 @@ func convertSchemaError(e *RequestError, innerErr *openapi3.SchemaError) *Valida
 		cErr.Detail = fmt.Sprintf("Value '%v' at %s must be one of: %s",
 			innerErr.Value, toJSONPointer(innerErr.JSONPointer()), strings.Join(enums, ", "))
 		value := fmt.Sprintf("%v", innerErr.Value)
-		if (e.Parameter.Explode == nil || *e.Parameter.Explode == true) &&
+		if e.Parameter != nil &&
+			(e.Parameter.Explode == nil || *e.Parameter.Explode == true) &&
 			(e.Parameter.Style == "" || e.Parameter.Style == "form") &&
 			strings.Contains(value, ",") {
 			parts := strings.Split(value, ",")


### PR DESCRIPTION
The parameter can be nil when the enum is set on the body